### PR TITLE
Expose root status endpoint for backend

### DIFF
--- a/backend/backend_app.py
+++ b/backend/backend_app.py
@@ -52,6 +52,11 @@ async def shutdown_event():
     await db.close()
     logger.info("Database connection closed")
 
+# Root endpoint
+@app.get("/")
+async def root():
+    return {"message": "TableHub backend is running", "docs": "/docs"}
+
 # Health check endpoint
 @app.get("/healthz")
 async def health_check():


### PR DESCRIPTION
## Summary
- add `/` route to backend to confirm service is running

## Testing
- `pytest`
- `uvicorn backend_app:app --port 8000 --host 0.0.0.0` and `curl -i http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_68a16a16b77c8328bdf0b74c57d6393b